### PR TITLE
Add expected/actual results to the error message.

### DIFF
--- a/src/koan_engine/util.clj
+++ b/src/koan_engine/util.clj
@@ -38,11 +38,13 @@
   [x] {
        :expected (try (eval (second x))
                       (catch Throwable e#
-                        "Evaluation error")),
+                        (str 
+                          "Evaluation error -- " (.getMessage e#)))),
 
        :actual (try (eval (nth x  2))
                     (catch Throwable e#
-                      "Evaluation error"))
+                      (str 
+                        "Evaluation error -- " (.getMessage e#))))
        })
 
 (defn expectations_to_s


### PR DESCRIPTION
Hello,
Thank you for such a beautiful application. I really appreciate being able to pick up Cloujure
in such a fun way.

So while I am going through the koans I found that often I make a stupid mistake that results in
expected result not equal to the actual.  Usually in this case I then go through the process of copying
the koan to the clipboard, closing out the editor and opening the lein REPL and evaluating my answer
there to see what is happening.

As you can imagine that process becomes pretty tedious.  So I made a change to the clojure-koan-engine
that helps in that scenario.

This pull request adds two functions,expectations[] and expectations_to_s[]
that are then used to add expected and actual evaluated results to the
error message in the form:

expected: expected-result
actual: actual-result

This should help give the student more of a hint as to why a koan is failing.

For instance, one result could be:

```
Now meditate upon /home/vagrant/clojure-koans/src/koans/02_lists.clj:3
---------------------
Assertion failed!
Lists can be expressed by function or a quoted form
(= (quote (1 4 3 4 5)) (list 1 2 3 4 5))

-------------
expected: (1 4 3 4 5)
actual: (1 2 3 4 5)
```

So having extra bit of information can make the learning experience a little easier.
