### PR TITLE
Add evaluation errors to koan message.

### DIFF
--- a/src/koan_engine/util.clj
+++ b/src/koan_engine/util.clj
@@ -4,7 +4,8 @@
             [clojure.java.io :as io])
   (:import [java.net URLDecoder]))
 
-(declare get-evaluation-errors-proxy answered? print-evaluation-error-string)
+(declare get-evaluation-errors-proxy answered?
+         evaluation? print-evaluation-error-string)
 
 (defn version<
   "< for Clojure's version map."
@@ -48,7 +49,7 @@
   the error message string."
   [koan error]
   (if
-    (answered? koan)
+    (and (answered? koan) (evaluation? error))
     (print-evaluation-error-string error) 
     ""))
 
@@ -57,6 +58,11 @@
   or false otherwise."
   [koan]
   (not-any? #{"__"} (split (str koan) #"\s+")))
+
+(defn evaluation?
+  "Verify that the error is not a mere assertion failure."
+  [error]
+  (not-any? #{"Assert"} (split (.getMessage error) #"\s+")))
 
 (defn print-evaluation-error-string
   "Formats and returns the koan evaluation error message."


### PR DESCRIPTION
This pull request attempts to implement the second option proposed in the
discussion to issue #6:

This change adds the evaluation errors that occur in the course
of testing a koan to the default koan message.

These errors are not added if the user has not completed the koan (i.e. there
are still "__" in the koan).

Below is an example of the type of output this change introduces:

```
Now meditate upon /home/vagrant/clojure-koans/src/koans/17_macros.clj:42
---------------------
Assertion failed!
Really, you don't understand recursion until you understand recursion
(= 36 (r-infix (10 + (2 * 3) + (4 * 5))))

-------------
Part-2 Error: java.lang.Long cannot be cast to clojure.lang.IFn
```
