### PR TITLE
Exit engine process on koan failure.

### DIFF
--- a/src/koan_engine/koans.clj
+++ b/src/koan_engine/koans.clj
@@ -42,7 +42,7 @@
              (println (.replaceFirst
                         (.replaceFirst message "^Assert failed: " "")
                         "^\\[LINE \\d+\\] " "")))
-           false))))
+           (System/exit 0)))))
 
 (defn namaste []
   (println "\nYou have achieved clojure enlightenment. Namaste."))


### PR DESCRIPTION
This pull request adds a change that  forces the process to exit on a koan failure.
This change makes it unnecessary for the user to have to Ctrl-C
out of the process after a koan failure.
