### PR TITLE
Remove name-spaces from koans on slurp.

### DIFF
--- a/src/koan_engine/checker.clj
+++ b/src/koan_engine/checker.clj
@@ -16,7 +16,8 @@
                                (repeat k)))))))
 
 (defn koan-text [koan-root koan]
-  (slurp (file koan-root (str koan ".clj"))))
+  (let [text (slurp (file koan-root (str koan ".clj")))]
+    (string/replace text #"(?s)\(ns.*koan-engine\.core\)\)" "")))
 
 (defn answers-for [koan-resource koan sym]
   (let [answers (mk-answers koan-resource)]


### PR DESCRIPTION
There are a couple of proposals (functional-koans/clojure-koans#69, 
functional-koans/clojure-koans#71) that will add a name-space to the koans 
files in order to fix an issue related to the REPL.

If one of these pull request is merged in, then a change like this one
will be needed in order to maintain a pass on `lein koan test`.
