### PR TITLE
random runner

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject koan-engine "0.2.2"
+(defproject koan-engine "0.2.3"
   :description "Koan Engine for Clojure projects."
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [fresh "1.0.2"]

--- a/src/koan_engine/random.clj
+++ b/src/koan_engine/random.clj
@@ -1,0 +1,77 @@
+(ns koan-engine.random
+  (:require [koan-engine.koans :refer [ordered-koans]]
+            [koan-engine.util :as u]
+            [clojure.java.io :refer [file]]
+            [clojure.string :as s]))
+
+(def success-quotes
+  ["Hack and be marry!"
+   "You're bound to be unhappy if you optimize everything. -Donald Knuth"
+   "Lisp isn't a language, it's a building material. -Alan Kay"
+   "The key to performance is elegance. -Jon Bentley and Doug McIlroy"
+   "Code long and prosper!"])
+
+(def failure-quotes
+  ["If at first you don't succeed; call it version 0.1"
+   "I would love to change the world, but they won't give me the source code."
+   "Loosing is fun. -Dwarf Fortress"
+   "Deleted code is debugged code. -Jeff Sickel"])
+
+(defn- solve-koan [koan]
+  (print "and the solution is (';' as delimiter): ")
+  (flush)
+  (let [solutions (s/split (read-line) #";")
+        filled-koan (reduce (fn [k s] (s/replace-first k #"\b___?\b" s)) koan solutions)]
+    (println)
+    (println "Your solution:\n" filled-koan)
+    (if
+        (or (try
+              (load-string filled-koan)
+              (catch AssertionError e (prn e) false)
+              (catch Exception e (prn e) false))
+            (= (symbol "skip-koan") (first solutions))
+            (= "skip-koan" (first solutions))
+            (= :skip-koan (first solutions)))
+      (println "Success. " (-> success-quotes shuffle first) "\nNext koan is coming up.\n")
+      (do
+        (println "Failed." (-> failure-quotes shuffle first) "\nTry again!")
+        (solve-koan koan)))))
+
+(defmacro random-koan [prefix-forms & forms]
+  (let [koan (->> forms
+                  (partition 2)
+                  shuffle
+                  first)]
+    ((fn [[doc# code#]]
+       (println "Solve the following koan:")
+       (println "meditate: " doc#)
+       (println code#)
+       (solve-koan (str prefix-forms code#)))
+     koan)))
+
+(defn- do-run [opts]
+  (let [{:keys [dojo-resource koan-resource koan-root]} opts
+        koan-file (-> koan-resource
+                 ordered-koans
+                 shuffle
+                 first)
+        form (s/replace (slurp (file koan-root (str koan-file ".clj")))
+                             #"\(ns" "(comment")
+        form-wo-meditations (-> form
+                                (s/replace #"\(meditations[\s\S]*" "")
+                                (s/replace "\"" "\\\""))]
+    (println "\nmeditating uppon: " koan-file)
+    (println "the contex of the koan:\n" form-wo-meditations)
+    (u/with-dojo [dojo-resource]
+      (-> (s/replace form "(meditations" (format "(random-koan \"%s\"" form-wo-meditations))
+          load-string)))
+  (do-run opts))
+
+(defn runner [opts]
+  (println
+"Showing a random koan from the project.
+You might never reach enlightement but you can play endlessly until you get bored and start writing your own koans!")
+  (println)
+  (println
+"Provide your answer or \"skip-koan\" if you want to skip the current one. You will automatically get the next random koan on success. Use ';' as delimiter if you need to provide multiple answers. If you need to provide multiple answers but only some of those have effect on the given koan you have to provide your solution in the right place; however, what you type for the rest is not important, you can keep them blank or use :skip.")
+  (do-run opts))

--- a/src/koan_engine/runner.clj
+++ b/src/koan_engine/runner.clj
@@ -1,7 +1,8 @@
 (ns koan-engine.runner
   (:use [koan-engine.freshness :only [setup-freshener]])
   (:require [koan-engine.util :as u]
-            [koan-engine.checker :as checker]))
+            [koan-engine.checker :as checker]
+            [koan-engine.random :as random]))
 
 (def default-koan-map
   {:koan-root "src/koans"
@@ -16,4 +17,5 @@
                         (:koan (u/read-project)))]
     (case task
       "run"  (setup-freshener koan-map)
-      "test" (checker/test koan-map))))
+      "test" (checker/test koan-map)
+      "random" (random/runner koan-map))))

--- a/src/koan_engine/util.clj
+++ b/src/koan_engine/util.clj
@@ -67,6 +67,7 @@
                  (read-string (format "(do %s)" (slurp dojo#))))]
      (do-isolated
        (use '~'[koan-engine.core :only [meditations __ ___]]
+            '~'[koan-engine.random :only [random-koan]]
             '~'[koan-engine.checker :only [ensure-failure]])
        (eval dojo#)
        ~@body)))


### PR DESCRIPTION
## Features
- adds random runner so a random koan is selected to be solved (needs a
  small modification of the lein plugin for `lein koan random` to work)
- on success next random koan is selected
- on failure the same koan presented again
- there is an option to skip-koan if the padawan/playful master wants to proceed to the
  next koan without providing good solution
- if multiple placeholders are present in the koan, multiple solutions
  can be typed in with ';' as delimiter
- the context of the koan is presented and considered for
  placeholders (typically when the koan file contains not fully
  implemented functions, macros)
## Known limitations
- needs a change in `lein-koan` will provide a pull a request there too
## Possible improvements
- if pull request gets accepted will create a pull request in `clojure-koans` and add a proper description of the feature to the readme
