### PR TITLE
Output relative path

### DIFF
--- a/src/koan_engine/koans.clj
+++ b/src/koan_engine/koans.clj
@@ -33,8 +33,6 @@
 
 (defn tests-pass? [dojo-path file-path]
   (u/with-dojo [dojo-path]
-    (print "Considering" (str file-path "..."))
-    (println)
     (flush)
     (try (load-file file-path)
          true

--- a/src/koan_engine/koans.clj
+++ b/src/koan_engine/koans.clj
@@ -1,6 +1,7 @@
 (ns koan-engine.koans
   (:use [clojure.java.io :only [file resource]])
-  (:require [koan-engine.util :as u]))
+  (:require [koan-engine.util :as u]
+            [clojure.string :as str]))
 
 ;; TODO: Proper koan validation. Accept the path as an argument.
 (defn ordered-koans [answer-path]
@@ -24,7 +25,7 @@
 (defn report-error [file-path line error]
   (let [message (or (.getMessage error) (.toString error))]
     (println "\nNow meditate upon"
-             (str file-path
+             (str (last (str/split file-path #"/"))
                   (when line (str ":" line))))
     (println "---------------------")
     (println "Assertion failed!")


### PR DESCRIPTION
Previously, the runner printed the entire file path when loading the koans, as well as every file being loaded. This made the output unnecessarily verbose.

Displaying only the relative path to the file that is being worked on looks cleaner and easier to read, since you already know where the koans are.

Paired with @tbaik